### PR TITLE
Fix tag filtering

### DIFF
--- a/plugin/const.go
+++ b/plugin/const.go
@@ -9,7 +9,6 @@ const (
 	constCredsLastRotatedTime      = "creds_last_rotated_time"
 	constSecretId                  = "secret_id"
 	constTenantId                  = "tenant_id"
-	constProvisioningState         = "provisioningState"
 	constDefaultFilter             = "resourceType eq 'Microsoft.Compute/virtualMachines'"
 	constMsComputeService          = "Microsoft.Compute"
 	constVirtualMachinesResource   = "virtualMachines"

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -333,7 +333,7 @@ func (p *AzurePlugin) ListHosts(ctx context.Context, req *pb.ListHostsRequest) (
 		// List values matching the filter; ask for provisioning state information
 		// to ensure we are seeing only fully provisioned machines
 		{
-			iter, err := resClient.ListComplete(ctx, filter, constProvisioningState, nil)
+			iter, err := resClient.ListComplete(ctx, filter, "", nil)
 			if err != nil {
 				return nil, fmt.Errorf("error listing resources: %w", err)
 			}
@@ -345,12 +345,8 @@ func (p *AzurePlugin) ListHosts(ctx context.Context, req *pb.ListHostsRequest) (
 				if val.ID == nil { // something went wrong, likely iterator has advanced beyond the end
 					continue
 				}
-				if val.ProvisioningState == nil {
-					continue
-				}
-				switch *val.ProvisioningState {
-				case string(resources.ProvisioningStateSucceeded):
-				default:
+				if val.Type == nil || *val.Type != "Microsoft.Compute/virtualMachines" {
+					// no point continuing if we can't validate that it's a VM
 					continue
 				}
 				resourceInfos = append(resourceInfos, val)


### PR DESCRIPTION
It turns out you can't filter on both resource type and tags at the same time, which means checking type needs to happen in code. Additionally, you can't request provisioning state because populating $expand also does bad things when using tags in filters.