### PR TITLE
use azure VM resource name as name in boundary

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -386,10 +386,12 @@ func (p *AzurePlugin) ListHosts(ctx context.Context, req *pb.ListHostsRequest) (
 
 	ret := &pb.ListHostsResponse{}
 	for k, v := range vmToNetworkMap {
+		splitId := strings.Split(strings.TrimLeft(k, "/"), "/")
 		host := &pb.ListHostsResponseHost{
 			ExternalId:  k,
 			IpAddresses: v.IpAddresses,
 			SetIds:      resourceToSetMap[k],
+			Name:        splitId[len(splitId)-1],
 		}
 		ret.Hosts = append(ret.Hosts, host)
 	}


### PR DESCRIPTION
As mentioned in issue #1821 in boundary project (https://github.com/hashicorp/boundary/issues/1821), dynamic host catalogs are nearly unusable via admin console or desktop app, because discovered hosts don't get a human identifiable name. Only internal id is displayed.
With this PR, the azure resource name is used as hostname in azure.